### PR TITLE
Add volume up/down commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This plugin requires the use of the Spotify Web API, which is only accessible th
 | `` sp pause ``                     | Pause currently playing track                    |
 | `` sp mute ``                      | Toggle Mute                                      |
 | `` sp volume {level}``             | Set Volume (absolute 1-100 or relative +/- 20)   |
+| `` sp up {amount}``                | Increase volume (default 10 if amount omitted)   |
+| `` sp down {amount}``              | Decrease volume (default 10 if amount omitted)   |
 | `` sp device ``                    | Set Active Device                                |
 | `` sp shuffle ``                   | Toggle Shuffle Mode                              |
 | `` sp reconnect ``                 | Force a full reconnection                        |

--- a/SpotifyPlugin.cs
+++ b/SpotifyPlugin.cs
@@ -65,6 +65,8 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
             _terms.Add("mute", ToggleMute);
             _terms.Add("vol", SetVolume);
             _terms.Add("volume", SetVolume);
+            _terms.Add("up", VolumeUp);
+            _terms.Add("down", VolumeDown);
             _terms.Add("shuffle", ToggleShuffle);
             _terms.Add("unlike", UnlikeCurrentSong);
 
@@ -331,6 +333,42 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
             }
 
             return SingleResultInList($"Volume", $"Current Volume: {cachedVolume}", action: () => { });
+        }
+
+        private List<Result> VolumeUp(string arg = null)
+        {
+            cachedVolume = _client.CurrentVolume;
+            int change = 10;
+            if (!string.IsNullOrWhiteSpace(arg) && int.TryParse(arg, out var step))
+            {
+                change = step;
+            }
+
+            int target = cachedVolume + change;
+            if (target > 100) target = 100;
+
+            return SingleResultInList(
+                $"Increase Volume to {target}",
+                $"Current Volume: {cachedVolume}",
+                action: () => { _client.SetVolume(target); });
+        }
+
+        private List<Result> VolumeDown(string arg = null)
+        {
+            cachedVolume = _client.CurrentVolume;
+            int change = 10;
+            if (!string.IsNullOrWhiteSpace(arg) && int.TryParse(arg, out var step))
+            {
+                change = step;
+            }
+
+            int target = cachedVolume - change;
+            if (target < 0) target = 0;
+
+            return SingleResultInList(
+                $"Decrease Volume to {target}",
+                $"Current Volume: {cachedVolume}",
+                action: () => { _client.SetVolume(target); });
         }
 
         private List<Result> ToggleShuffle(string arg = null)

--- a/SpotifyPluginClient.cs
+++ b/SpotifyPluginClient.cs
@@ -261,9 +261,13 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
             var volRequest = new PlayerVolumeRequest(volumePercent);
             _spotifyClient.Player.SetVolume(volRequest).GetAwaiter().GetResult();
 
-            // New volume percentage can not be retrieved even after fully waiting for the call to finish.
-            // Manually wait so API can return the updated volume after this call.
-            while (mLastVolume == CurrentVolume) { }
+            // New volume percentage cannot be retrieved even after fully waiting for the call to finish.
+            // Manually poll the API for a short period instead of blocking endlessly.
+            var retries = 20;
+            while (mLastVolume == CurrentVolume && retries-- > 0)
+            {
+                Thread.Sleep(50);
+            }
         }
 
         public void ToggleShuffle()


### PR DESCRIPTION
## Summary
- add `up` and `down` commands to quickly change volume
- document the commands in README

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841cf1d30f48320be7aef2ad1a3ffbb